### PR TITLE
Fix for Rails 6+ unnecessary dependency lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Why did I fork this repo?
 
-The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 5+ and I have created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in Rails 6+.
+The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 5+ and I have created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in future versions of Rails.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Why did I fork this branch?
+# Why did I fork this repo?
 
 The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 5+ and I ahve created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in Rails 6+.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Why did I fork this repo?
 
-The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 5+ and I ahve created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in Rails 6+.
+The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 5+ and I have created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in Rails 6+.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Why did I fork this repo?
 
-The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 5+ and I have created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in future versions of Rails.
+The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 6+ and I have created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in future versions of Rails.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plus, with our custom methods you don't have to write `<div class="box"></div>` 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'flexbox_rb'
+gem 'flexbox_rb', github: 'ben-gy/flexbox_rb'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Why did I fork this branch?
+
+The original gem is not currently being actively maintained. There was a required fix needed to make the gem work when using on Rails 5+ and I ahve created a pull request but it has not yet been merged. I have merged that branch and forked the repo so I can maintain it further if I run into future problems in Rails 6+.
+
+---
+
 # FlexboxRb
 
 FlexBoxRb is a wrapper for the awesome gryd system from [@kristoferjoseph](https://github.com/kristoferjoseph), original project can be found here: https://github.com/kristoferjoseph/flexboxgrid.

--- a/flexbox_rb.gemspec
+++ b/flexbox_rb.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
-  spec.add_dependency("railties", ">= 3.2.6", "< 6")
+  spec.add_dependency("railties", ">= 3.2.6")
 end


### PR DESCRIPTION
Fixes a breaking error where the gem doesn't work on Rails 6. I believe this gem is simple enough to take a default assumption that it will work with future Rails versions instead of locking an upper bound on a major version.